### PR TITLE
Fix hostile ship boss bar missing

### DIFF
--- a/src/main/java/com/lulan/shincolle/entity/BasicEntityShipHostile.java
+++ b/src/main/java/com/lulan/shincolle/entity/BasicEntityShipHostile.java
@@ -23,16 +23,12 @@ import com.lulan.shincolle.reference.ID;
 import com.lulan.shincolle.reference.unitclass.Attrs;
 import com.lulan.shincolle.reference.unitclass.AttrsAdv;
 import com.lulan.shincolle.reference.unitclass.MissileData;
-import com.lulan.shincolle.utility.BlockHelper;
-import com.lulan.shincolle.utility.BuffHelper;
-import com.lulan.shincolle.utility.CombatHelper;
-import com.lulan.shincolle.utility.DebugProfiler;
-import com.lulan.shincolle.utility.EntityHelper;
-import com.lulan.shincolle.utility.TargetHelper;
+import com.lulan.shincolle.utility.*;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.server.LoggedPrintStream;
 import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
@@ -171,11 +167,6 @@ public abstract class BasicEntityShipHostile extends Mob
 		this.shipMoveHelper = new ShipMoveHelper(this, 60F);
 		this.shipAttrs = new AttrsAdv(this.getShipClass());
 
-		// init boss bar if scale level >= 2
-		if (this.scaleLevel >= 2 && !this.level().isClientSide()) {
-			this.bossEvent = new ServerBossEvent(
-					this.getDisplayName(), bossBarColor, BossEvent.BossBarOverlay.PROGRESS);
-		}
 	}
 
 	// ========== Static Attribute Builder ==========
@@ -226,6 +217,7 @@ public abstract class BasicEntityShipHostile extends Mob
 		if (!this.level().isClientSide()) {
 			calcShipAttributes(31, false);
 		}
+		creatBossEvent();
 	}
 
 	/** Set size based on scale level */
@@ -386,6 +378,12 @@ public abstract class BasicEntityShipHostile extends Mob
 		ModNetworking.sendToPlayer(S2CEntitySyncPacket.syncScale(this, this.getScaleLevel()), player);
 		if (this.bossEvent != null) {
 			this.bossEvent.addPlayer(player);
+		}
+	}
+	public void creatBossEvent() {
+		if (this.scaleLevel >= 2 && !this.level().isClientSide()) {
+			this.bossEvent = new ServerBossEvent(
+					this.getDisplayName(), bossBarColor, BossEvent.BossBarOverlay.PROGRESS);
 		}
 	}
 


### PR DESCRIPTION
Remove broken boss bar creation from postInit() where scaleLevel is always 0 at construction time Add creatBossEvent() method to create boss bar when scale >= 2 Call creatBossEvent() in initAttrs() where scaleLevel have been initialized

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing boss bar for hostile ships by creating the `ServerBossEvent` after the ship’s scale is initialized. The boss bar now appears correctly for ships with `scaleLevel >= 2`.

- **Bug Fixes**
  - Added `creatBossEvent()` and call it from `initAttrs()`; removed boss bar creation from `postInit()` where `scaleLevel` was 0.
  - Ensures `startSeenByPlayer()` attaches players to an initialized boss bar, preventing the bar from missing on spawn.

<sup>Written for commit f69f4f758700b7b97f7f7b3b6bded36384076e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kousakirai/ShinColle-Reforge/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

