### PR TITLE
added fix for ship not spawning with full HP

### DIFF
--- a/src/main/java/com/lulan/shincolle/entity/BasicEntityShipHostile.java
+++ b/src/main/java/com/lulan/shincolle/entity/BasicEntityShipHostile.java
@@ -218,6 +218,7 @@ public abstract class BasicEntityShipHostile extends Mob
 			calcShipAttributes(31, false);
 		}
 		creatBossEvent();
+		setHealth(this.getMaxHealth());
 	}
 
 	/** Set size based on scale level */


### PR DESCRIPTION
fix for #18, added setHealth(this.getMaxHealth()); in BasicEntityShipHostile initAttrs,

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure hostile ships and bosses spawn at full HP by setting health to max in `BasicEntityShipHostile.initAttrs`, preventing newly spawned bosses from appearing partially damaged.

<sup>Written for commit 94ab247b4019ff10816b64b7845ae6688495ca75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kousakirai/ShinColle-Reforge/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

